### PR TITLE
No more crashing on syntax error in buffer.

### DIFF
--- a/lib/jsx.js
+++ b/lib/jsx.js
@@ -25,9 +25,13 @@ module.exports = function(options) {
       }
 
       if (file.isBuffer()) {
-        file.contents = new Buffer(
-          jsx.fromString(file.contents.toString('utf8'), options)
-        );
+        try {
+          file.contents = new Buffer(
+            jsx.fromString(file.contents.toString('utf8'), options)
+          );
+        } catch (err) {
+          next(err);
+        }
       }
     }
 


### PR DESCRIPTION
Was having issues with gulp watch dying due to syntax error.  Seems like the fix for #8 missed this path.
